### PR TITLE
summary field added and required for post schema videoObject

### DIFF
--- a/_posts/2021-07-19-another-sample-post.md
+++ b/_posts/2021-07-19-another-sample-post.md
@@ -2,6 +2,9 @@
 layout: post
 title: Another Sample Post
 date: 2021-07-19T18:08:12.940Z
+# Limit 90 characters for SEO optimization
+excerpt: This is an example post for the Point Zero Jekyll theme. Photo by Dids
+  from Pexels.
 media:
   - type: featured_media_image
     path: /assets/images/pexels-dids-3705001.jpg

--- a/_posts/2021-07-19-john-whitney-catalog-1961.md
+++ b/_posts/2021-07-19-john-whitney-catalog-1961.md
@@ -2,6 +2,9 @@
 layout: post
 title: John Whitney Catalog, 1961
 date: 2021-07-19T19:18:47.294Z
+# Limit 90 characters for SEO optimization
+excerpt: Watch John Whitney's demo reel, created with an analog computer built
+  from WWII hardware.
 media:
   - type: featured_media_youtube
     youtubeID: TbV7loKp69s

--- a/_posts/2021-07-19-john-whitney-permutations-1969-generative-graphics.md
+++ b/_posts/2021-07-19-john-whitney-permutations-1969-generative-graphics.md
@@ -1,7 +1,9 @@
 ---
 layout: post
-title: John Whitney, Permutations 1969, Generative graphics
+title: John Whitney, Permutations 1966, Generative graphics
 date: 2021-07-19T19:15:15.626Z
+# Limit 90 characters for SEO optimization
+excerpt: Watch John Whitney's celebrated experimental film from 1969, Permutations.
 media:
   - type: featured_media_youtube
     youtubeID: 50CV6_tDJ9M

--- a/_posts/2021-07-19-jordan-belson-mandala-1953.md
+++ b/_posts/2021-07-19-jordan-belson-mandala-1953.md
@@ -2,6 +2,9 @@
 layout: post
 title: Jordan Belson - Mandala (1953)
 date: 2021-07-19T19:07:22.924Z
+# Limit 90 characters for SEO optimization
+excerpt: Watch Jordan Belson's Mandala (1953), one of 13 films from the Center
+  for Visual Music.
 media:
   - type: featured_media_youtube
     youtubeID: dH60wa2TuSk

--- a/_posts/2021-07-19-sample-post.md
+++ b/_posts/2021-07-19-sample-post.md
@@ -2,6 +2,9 @@
 layout: post
 title: Sample Post
 date: 2021-07-19T18:04:02.128Z
+# Limit 90 characters for SEO optimization
+excerpt: This is an example post for the Point Zero Jekyll theme. Photo by Dids
+  from Pexels.
 media:
   - type: featured_media_image
     path: /assets/images/pexels-bruno-thethe-1910225.jpg

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -26,6 +26,13 @@ collections:
       - { label: 'Layout', name: 'layout', widget: 'hidden', default: 'post' }
       - { label: 'Title', name: 'title', widget: 'string' }
       - { label: 'Publish Date', name: 'date', widget: 'datetime' }
+      - {
+        label: "Short Excerpt",
+        name: "excerpt",
+        widget: "text",
+        pattern: ["^.{50,90}$", "Must be between 50–90 characters"],
+        comment: "Limit 90 characters for SEO optimization",
+      }
       - label: "Featured Media"
         name: "media"
         widget: "list"


### PR DESCRIPTION
To ensure best practices this solution adds a summary field to the post editor. The summary field is required, and is currently restricted to 50-90 characters. 

looking at search results now I think the limit can be safely increased to 140 characters without having the summary cut off in search results.

Issue to increase the limit is here: https://github.com/discoform/point-zero/issues/15

closes https://github.com/discoform/point-zero/issues/12